### PR TITLE
Update GameScreen.java

### DIFF
--- a/core/src/net/asg/games/dante/screens/GameScreen.java
+++ b/core/src/net/asg/games/dante/screens/GameScreen.java
@@ -120,7 +120,7 @@ public class GameScreen extends AbstractScreen {
         levelManager = new LevelManager();
 
         Gdx.input.setInputProcessor(this);
-        Gdx.input.setCatchBackKey(true);
+        //Gdx.input.setCatchBackKey(true);
     }
 
     @Override


### PR DESCRIPTION
Remove Back Key catch.  The game while running should not catch the back key.  There is code to keep the instance persistent by using JSON.  If focus is lost, the instance is restored from the JSON state file.
